### PR TITLE
add JPY rate info

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,10 +5,15 @@ const path = "docs/latest.json";
 
 request("https://rate.bot.com.tw/xrt/flcsv/0/day")
   .then(body => {
-    const usdInfo = body.split(/\r?\n/)[1];
+    const rateInfo = body.split(/\r?\n/);
+    const usdInfo = rateInfo[1];
+    const jpyInfo = rateInfo[8];
     return {
       dataAsOf: new Date().toLocaleDateString(),
-      conversions: { USD: { TWD: usdInfo.split(",")[3] } }
+      conversions: {
+        USD: { TWD: usdInfo.split(",")[3] },
+        JPY: { TWD: jpyInfo.split(",")[3] } 
+      }
     };
   })
   .then(data => promises.writeFile(path, JSON.stringify(data)));


### PR DESCRIPTION
This is a proposal to add Japanese yen(JPY) rate information to your repositories.
Execution Result: https://t.gyazo.com/teams/flux-g/f9cd279ce8a560b1a20861d9a5013529.png

We would like to use this tool, so I would be very happy if you could merge this change.